### PR TITLE
Only defer client.Logout if client has been successfully returned.

### DIFF
--- a/vsphere-influxdb.go
+++ b/vsphere-influxdb.go
@@ -131,12 +131,12 @@ func (vcenter *VCenter) Init(config Configuration) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	client, err := vcenter.Connect()
-	defer client.Logout(ctx)
 	if err != nil {
 		errlog.Println("Could not connect to vcenter: ", vcenter.Hostname)
 		errlog.Println("Error: ", err)
 		return
 	}
+	defer client.Logout(ctx)
 	var perfmanager mo.PerformanceManager
 	err = client.RetrieveOne(ctx, *client.ServiceContent.PerfManager, nil, &perfmanager)
 	if err != nil {
@@ -182,12 +182,12 @@ func (vcenter *VCenter) Query(config Configuration, InfluxDBClient influxclient.
 
 	// Get the client
 	client, err := vcenter.Connect()
-	defer client.Logout(ctx)
 	if err != nil {
 		errlog.Println("Could not connect to vcenter: ", vcenter.Hostname)
 		errlog.Println("Error: ", err)
 		return
 	}
+	defer client.Logout(ctx)
 
 	// Create the view manager
 	var viewManager mo.ViewManager


### PR DESCRIPTION
Hi Adrian,
Thanks for sharing these codes.
I found a bug which arised in the scenarios when error occured in vcenter.Connect(). Then when go exec the defer client.Logout(ctx) codes, a null point panic arised since client has never been initialized. A better idea is to move defer client.Logout(ctx) afer if err != nil codes. Here is the codes. 

--- a/vsphere-influxdb.go
+++ b/vsphere-influxdb.go
@@ -131,12 +131,12 @@ func (vcenter *VCenter) Init(config Configuration) {
        ctx, cancel := context.WithCancel(context.Background())
        defer cancel()
        client, err := vcenter.Connect()
-       defer client.Logout(ctx)
      if err != nil {
              errlog.Println("Could not connect to vcenter: ", vcenter.Hostname)
              errlog.Println("Error: ", err)
              return
      }
-       defer client.Logout(ctx)
      var perfmanager mo.PerformanceManager

Best wishes
lucas
