### PR TITLE
Compute usage percentage of datastore.

### DIFF
--- a/vsphere-influxdb.go
+++ b/vsphere-influxdb.go
@@ -719,6 +719,7 @@ func (vcenter *VCenter) Query(config Configuration, InfluxDBClient influxclient.
 			datastoreFields := map[string]interface{}{
 				"capacity":   datastore.Summary.Capacity,
 				"free_space": datastore.Summary.FreeSpace,
+				"usage":      1.0 - (float64(datastore.Summary.FreeSpace)/float64(datastore.Summary.Capacity)),
 			}
 			datastoreTags := map[string]string{"ds_name": datastore.Summary.Name, "host": vcName}
 			pt4, err := influxclient.NewPoint(config.InfluxDB.Prefix+"datastore", datastoreTags, datastoreFields, time.Now())


### PR DESCRIPTION
I would like to display the usage of my datastores as a percentage in Grafana. However, as far as I can tell, it is not possible to "compute" this value in Grafana with the InfluxDB data source with just the `capacity` and `free_space` values. 

Thus I added another datastore field `usage` that computes the usage of a datastore as a percentage (0.0 - 1.0) in the script and stores the value in InfluxDB.